### PR TITLE
Allow explicitly setting interaction mode via API

### DIFF
--- a/vim/autoload/vlime/plugin.vim
+++ b/vim/autoload/vlime/plugin.vim
@@ -1132,18 +1132,18 @@ endfunction
 " @public
 "
 " Toggle interaction mode.
-function! vlime#plugin#InteractionMode()
-    if getbufvar(bufnr('%'), 'vlime_interaction_mode', v:false)
-        let b:vlime_interaction_mode = v:false
-        nnoremap <buffer> <cr> <cr>
-        vnoremap <buffer> <cr> <cr>
-        echom 'Interaction mode disabled.'
-    else
+function! vlime#plugin#InteractionMode(...)
+    let enable = get(a:000, 0, !getbufvar(bufnr('%'), 'vlime_interaction_mode', v:false))
+    if enable
         let b:vlime_interaction_mode = v:true
         nnoremap <buffer> <silent> <cr> :call vlime#plugin#SendToREPL(vlime#ui#CurExprOrAtom())<cr>
         vnoremap <buffer> <silent> <cr> :<c-u>call vlime#plugin#SendToREPL(vlime#ui#CurSelection())<cr>
-        echom 'Interaction mode enabled.'
+    else
+        let b:vlime_interaction_mode = v:false
+        nnoremap <buffer> <cr> <cr>
+        vnoremap <buffer> <cr> <cr>
     endif
+    echom 'Interaction mode ' . (enable ? 'enabled' : 'disabled') . '.'
 endfunction
 
 function! s:NormalizeIdentifierForIndentInfo(ident)

--- a/vim/doc/vlime-api.txt
+++ b/vim/doc/vlime-api.txt
@@ -885,9 +885,10 @@ vlime#plugin#Setup([force])                             *vlime#plugin#Setup()*
   already initialized. If [force] is present and |TRUE|, always perform the
   initialization.
 
-vlime#plugin#InteractionMode()                *vlime#plugin#InteractionMode()*
+vlime#plugin#InteractionMode([value])         *vlime#plugin#InteractionMode()*
 
-  Toggle interaction mode.
+  Toggle interaction mode if no [value] is given. If [value] is |TRUE| enable
+  interaction mode, if [value] is |FALSE| disable it.
 
 vlime#ui#New()                                                *vlime#ui#New()*
 


### PR DESCRIPTION
The user can pass an optional boolean argument to the API function `vlime#plugin#InteractionMode()` to explicitly set interaction mode. If no value is given the mode will be toggled according the previously existing rules. Thus this commit does not break the API.

As an example, I like to have interaction mode running by default, so I added to my `ftplugin/lisp.vim` file the following line of code:
~~~ vim
silent call vlime#plugin#InteractionMode(v:true)
~~~