### PR TITLE
Fix indentation to follow the general CL convention

### DIFF
--- a/vim/autoload/vlime/plugin.vim
+++ b/vim/autoload/vlime/plugin.vim
@@ -1040,6 +1040,13 @@ function! vlime#plugin#CalcCurIndent(...)
 
     let vs_col = virtcol(op_list[0][2])
 
+    " 0. Quoted list
+    for item in op_list
+      if item[0] == 'quote'
+        return vs_col
+      endif
+    endfor
+
     let a_count = v:null
 
     " 1. Special forms such as FLET

--- a/vim/autoload/vlime/plugin.vim
+++ b/vim/autoload/vlime/plugin.vim
@@ -1070,8 +1070,12 @@ function! vlime#plugin#CalcCurIndent(...)
         endif
 
         let indent_info = get(conn.cb_data, 'indent_info', {})
-        if has_key(indent_info, op) && index(indent_info[op][1], op_pkg) >= 0
+        if has_key(indent_info, op)
+          if index(indent_info[op][1], op_pkg) >= 0
             let a_count = indent_info[op][0]
+          else " Set it anyway in case that 'op_pkg' is a nickname
+            let a_count = indent_info[op][0]
+          endif
         endif
     endif
 

--- a/vim/autoload/vlime/plugin.vim
+++ b/vim/autoload/vlime/plugin.vim
@@ -1047,9 +1047,9 @@ function! vlime#plugin#CalcCurIndent(...)
       endif
     endfor
 
-    " 1. lambda-list in DEFUN/DEFGENERIC/DEFMETHOD
+    " 1. lambda-list in DEFUN/DEFGENERIC/DEFMETHOD/DEFMACRO
     if len(op_list) >= 2 &&
-          \ index(['defun', 'defgeneric', 'defmethod'], tolower(op_list[1][0])) >= 0 &&
+          \ index(['defun', 'defgeneric', 'defmethod', 'defmacro'], tolower(op_list[1][0])) >= 0 &&
           \ op_list[0][2][0] == op_list[1][2][0]
       " lambda-list in DEFUN/DEFGENERIC/DEFMETHOD
       return vs_col

--- a/vim/autoload/vlime/plugin.vim
+++ b/vim/autoload/vlime/plugin.vim
@@ -1047,9 +1047,17 @@ function! vlime#plugin#CalcCurIndent(...)
       endif
     endfor
 
+    " 1. lambda-list in DEFUN/DEFGENERIC/DEFMETHOD
+    if len(op_list) >= 2 &&
+          \ index(['defun', 'defgeneric', 'defmethod'], tolower(op_list[1][0])) >= 0 &&
+          \ op_list[0][2][0] == op_list[1][2][0]
+      " lambda-list in DEFUN/DEFGENERIC/DEFMETHOD
+      return vs_col
+    endif
+
     let a_count = v:null
 
-    " 1. Special forms such as FLET
+    " 2. Special forms such as FLET
     let a_count = s:IndentCheckSpecialForms(op_list)
 
     if type(a_count) == type(v:null)
@@ -1061,12 +1069,12 @@ function! vlime#plugin#CalcCurIndent(...)
         let op = tolower(s:NormalizeIdentifierForIndentInfo(matches[3]))
     endif
 
-    " 2. User defined indent keywords
+    " 3. User defined indent keywords
     if type(a_count) == type(v:null) && exists('g:vlime_indent_keywords')
         let a_count = get(g:vlime_indent_keywords, op, v:null)
     endif
 
-    " 3. Swank-provided indent keywords
+    " 4. Swank-provided indent keywords
     if type(a_count) == type(v:null) && type(conn) != type(v:null)
         let op_pkg = toupper(s:NormalizeIdentifierForIndentInfo(matches[2]))
         if len(op_pkg) == 0 && type(conn) != type(v:null)
@@ -1086,7 +1094,7 @@ function! vlime#plugin#CalcCurIndent(...)
         endif
     endif
 
-    " 4. Default indent keywords
+    " 5. Default indent keywords
     if type(a_count) == type(v:null)
         let a_count = get(g:vlime_default_indent_keywords, op, v:null)
     endif

--- a/vim/autoload/vlime/plugin.vim
+++ b/vim/autoload/vlime/plugin.vim
@@ -976,7 +976,7 @@ if !exists('g:vlime_default_indent_keywords')
                 \ 'defmethod': 2,
                 \ 'deftype': 2,
                 \ 'lambda': 1,
-                \ 'if': 1,
+                \ 'if': 3,
                 \ 'unless': 1,
                 \ 'when': 1,
                 \ 'case': 1,

--- a/vim/autoload/vlime/ui.vim
+++ b/vim/autoload/vlime/ui.vim
@@ -555,7 +555,11 @@ function! vlime#ui#ParseOuterOperators(max_count)
             let cur_pos = vlime#ui#CurArgPos([p_line, p_col])
 
             call setpos('.', [0, p_line, p_col, 0])
-            let cur_op = vlime#ui#CurOperator()
+            if matchstr(getline('.'), '\%' . (col('.')-1) . 'c.') == "'"
+              let cur_op = 'quote'
+            else
+              let cur_op = vlime#ui#CurOperator()
+            endif
             call add(stack, [cur_op, cur_pos, [p_line, p_col]])
         endwhile
     finally


### PR DESCRIPTION
- Fix the default indentation of `if` forms.
- Fix the indentation of lambda-list when it's long and written in multiple lines
- Fix the indentation of quoted lists
- Fix the `vlime#plugin#CalcCurIndent` to _guess_ the possible operator if it's not found