### PR TITLE
Make swank_repl a prompt buffer

### DIFF
--- a/vim/autoload/vlime/plugin.vim
+++ b/vim/autoload/vlime/plugin.vim
@@ -270,6 +270,18 @@ function! vlime#plugin#SendToREPL(...)
                 \ s:InputCheckEditFlag(
                     \ get(a:000, 1, v:false),
                     \ get(a:000, 0, v:null))
+
+    " Use prompt buffer instead of MaybeInput if prompt buffer is available
+    if type(content) == type(v:null)
+        if exists('*prompt_setprompt')
+            let repl_buf = vlime#ui#repl#InitREPLBuf(conn)
+            call vlime#ui#OpenBufferWithWinSettings(repl_buf, v:true, 'repl')
+            startinsert
+            return
+        end
+    end
+        
+
     call vlime#ui#input#MaybeInput(
                 \ content,
                 \ function('s:SendToREPLInputComplete', [conn]),

--- a/vim/autoload/vlime/ui/repl.vim
+++ b/vim/autoload/vlime/ui/repl.vim
@@ -158,10 +158,9 @@ function! s:InitREPLBuf()
         setlocal omnifunc=vlime#plugin#CompleteFunc
         setlocal indentexpr=vlime#plugin#CalcCurIndent()
         setlocal nomodified
-        autocmd InsertLeave <buffer> call append(line('$'), '') | setlocal nomodified
     else
         setlocal nomodifiable
     end
-
+    let b:matchup_delim_enabled=0
     call vlime#ui#MapBufferKeys('repl')
 endfunction

--- a/vim/autoload/vlime/ui/repl.vim
+++ b/vim/autoload/vlime/ui/repl.vim
@@ -86,7 +86,10 @@ function! s:ClearREPLBuffer_inBuffer()
         let b:vlime_repl_coords_match = []
     endif
     call s:ShowREPLBanner(b:vlime_conn)
-    setlocal nomodifiable
+
+    if !exists('*prompt_setprompt')
+        setlocal nomodifiable
+    endif
 endfunction
 
 function! vlime#ui#repl#NextField(forward)
@@ -143,7 +146,16 @@ function! s:InitREPLBuf()
 
     setlocal modifiable
     call s:ShowREPLBanner(b:vlime_conn)
-    setlocal nomodifiable
+
+    if exists('*prompt_setprompt')
+        setlocal buftype=prompt
+        call prompt_setprompt(bufnr(''), '')
+        call prompt_setcallback(bufnr(''), function('vlime#plugin#SendToREPL'))
+        setlocal omnifunc=vlime#plugin#CompleteFunc
+        setlocal indentexpr=vlime#plugin#CalcCurIndent()
+    else
+        setlocal nomodifiable
+    end
 
     call vlime#ui#MapBufferKeys('repl')
 endfunction

--- a/vim/autoload/vlime/ui/repl.vim
+++ b/vim/autoload/vlime/ui/repl.vim
@@ -30,6 +30,12 @@ function! vlime#ui#repl#AppendOutput(repl_buf, str)
     finally
         call setbufvar(a:repl_buf, '&modifiable', old_modifiable)
     endtry
+
+    " Protect the REPL out from being deleted if user is in REPL buffer.
+    if exists('*prompt_setprompt') && repl_winnr == winnr()
+        stopinsert
+        startinsert
+    end
 endfunction
 
 function! vlime#ui#repl#InspectCurREPLPresentation()

--- a/vim/autoload/vlime/ui/repl.vim
+++ b/vim/autoload/vlime/ui/repl.vim
@@ -35,6 +35,7 @@ function! vlime#ui#repl#AppendOutput(repl_buf, str)
     if exists('*prompt_setprompt') && repl_winnr == winnr()
         stopinsert
         startinsert
+        call setbufvar(a:repl_buf, '&modified', 0)
     end
 endfunction
 
@@ -159,6 +160,8 @@ function! s:InitREPLBuf()
         call prompt_setcallback(bufnr(''), function('vlime#plugin#SendToREPL'))
         setlocal omnifunc=vlime#plugin#CompleteFunc
         setlocal indentexpr=vlime#plugin#CalcCurIndent()
+        setlocal nomodified
+        autocmd InsertLeave <buffer> :setlocal nomodified
     else
         setlocal nomodifiable
     end

--- a/vim/autoload/vlime/ui/repl.vim
+++ b/vim/autoload/vlime/ui/repl.vim
@@ -31,10 +31,7 @@ function! vlime#ui#repl#AppendOutput(repl_buf, str)
         call setbufvar(a:repl_buf, '&modifiable', old_modifiable)
     endtry
 
-    " Protect the REPL out from being deleted if user is in REPL buffer.
-    if exists('*prompt_setprompt') && repl_winnr == winnr()
-        stopinsert
-        startinsert
+    if exists('*prompt_setprompt')
         call setbufvar(a:repl_buf, '&modified', 0)
     end
 endfunction
@@ -156,12 +153,12 @@ function! s:InitREPLBuf()
 
     if exists('*prompt_setprompt')
         setlocal buftype=prompt
-        call prompt_setprompt(bufnr(''), '')
-        call prompt_setcallback(bufnr(''), function('vlime#plugin#SendToREPL'))
+        call prompt_setprompt(bufnr(), ' ')
+        call prompt_setcallback(bufnr(), function('vlime#plugin#SendToREPL'))
         setlocal omnifunc=vlime#plugin#CompleteFunc
         setlocal indentexpr=vlime#plugin#CalcCurIndent()
         setlocal nomodified
-        autocmd InsertLeave <buffer> :setlocal nomodified
+        autocmd InsertLeave <buffer> call append(line('$'), '') | setlocal nomodified
     else
         setlocal nomodifiable
     end

--- a/vim/autoload/vlime/ui/sldb.vim
+++ b/vim/autoload/vlime/ui/sldb.vim
@@ -496,6 +496,7 @@ endfunction
 
 function! s:InitSLDBBuf()
     setlocal filetype=vlime_sldb
+    stopinsert
     call vlime#ui#MapBufferKeys('sldb')
 endfunction
 

--- a/vim/doc/vlime-tutor.txt
+++ b/vim/doc/vlime-tutor.txt
@@ -113,8 +113,9 @@ Now that we have an active connection, let's try something simple.
 Vlime has good REPL integration, but it's different from other Lisp
 environments, in that Vlime's REPL buffer is dedicated for output,
 i.e. you can not type and evaluate an expression directly in the REPL
-buffer. To evaluate something in the REPL, you send it using key
-mappings listed in |vlime-mappings-send|.
+buffer (except you're using are using a recent version of vim with 
+with buftype 'prompt').  To evaluate something in the REPL,
+you send it using key mappings listed in |vlime-mappings-send|.
 
 Let's go to ad-hoc.lisp, the file we created in |vlime-tutor-connect|,
 and write a simple expression in it:
@@ -138,12 +139,16 @@ result:
 
 This is the REPL buffer.
 
-Try typing "i" (without the quote marks) in the REPL buffer. It will
+Try typing "i" (without the quote marks) in the REPL buffer. It may
 result in an error message:
 
     E21: Cannot make changes, 'modifiable' is off
 
-Indeed, it's read-only.
+This means that your vim/neovim version does not support prompt buffers
+and that you can not enter text in the REPL directly. In that case, you
+use can use dedicated input buffer that vlime implements
+(|vlime-input-buffer|, default mapping: `<LocalLeader>si`).
+
 
 To make sending things to the REPL easier, Vlime has an interaction
 mode for *.lisp buffers. Go back to the ad-hoc.lisp buffer at the top,


### PR DESCRIPTION
Disclaimer: I have absolutely no idea of vim script.

Wouldn't it be nice if we could actually enter commands directly in the Swank repl? Even thought it's only a single line.

Btw. probably we need to  set the buffer to "not modified" when exiting to avoid the "buffer needs to be saved" message.

And debugger windows shouldn't be prompt buffers.