### PR TITLE
Fix automatic indentation in case of certain character literals

### DIFF
--- a/vim/autoload/vlime/ui.vim
+++ b/vim/autoload/vlime/ui.vim
@@ -595,7 +595,7 @@ function! vlime#ui#ParseOuterOperators(max_count)
     let old_cur_pos = getcurpos()
     try
         while len(stack) < a:max_count
-            let [p_line, p_col] = searchpairpos('(', '', ')', 'bnW', s:skipped_regions)
+            let [p_line, p_col] = vlime#ui#SearchParenPos('bnW')
             if p_line <= 0 || p_col <= 0
                 break
             endif

--- a/vim/autoload/vlime/ui.vim
+++ b/vim/autoload/vlime/ui.vim
@@ -579,7 +579,7 @@ endfunction
 " surrounding expression instead, if the cursor is on the left enclosing
 " parentheses.
 function! vlime#ui#SurroundingOperator()
-    let [s_line, s_col] = searchpairpos('(', '', ')', 'bnW')
+    let [s_line, s_col] = vlime#ui#SearchParenPos('bnW')
     if s_line > 0 && s_col > 0
         let op_line = getline(s_line)[(s_col-1):]
         let matches = matchlist(op_line, '^(\s*\(\k\+\)\s*')

--- a/vim/autoload/vlime/ui.vim
+++ b/vim/autoload/vlime/ui.vim
@@ -372,8 +372,9 @@ function! vlime#ui#CurExprPos(cur_char, ...)
       " Build an expression that detects whether the current cursor position is
       " in certain syntax types (string, comment, etc.), for use as
       " searchpairpos()'s skip argument.
+      " We match "escape" for special items, such as lispEscapeSpecial.
       let s_skip = '!empty(filter(map(synstack(line("."), col(".")), ''synIDattr(v:val, "name")''), ' .
-      \ '''v:val =~? s:skipped_regions''))'
+          \ '''v:val =~? "string\\|character\\|singlequote\\|escape\\|symbol\\|comment"''))'
       " If executing the expression determines that the cursor is currently in
       " one of the syntax types, then we want searchpairpos() to find the pair
       " within those syntax types (i.e., not skip).  Otherwise, the cursor is

--- a/vim/autoload/vlime/ui.vim
+++ b/vim/autoload/vlime/ui.vim
@@ -345,11 +345,6 @@ let s:cur_expr_pos_search_flags = {
             \ 'end':   ['nW', 'cnW', 'nW'],
             \ }
 
-" List syntax types to skip when using searchpairpos():
-" - "escape" for special items, such as lispEscapeSpecial.
-" - "symbol" for odd symbols like `|nice-(|`
-let s:skipped_regions = 'string\|character\|singlequote\|comment\|escape\|symbol'
-
 ""
 " @usage {cur_char} [side]
 " @public
@@ -421,6 +416,25 @@ function! vlime#ui#CurTopExpr(...)
     else
         return return_pos ? ['', [0, 0], [0, 0]] : ''
     endif
+endfunction
+
+""
+" @usage [flags]
+" @public
+"
+" Tiny searchpairpos() wrapper tailored for searching pairs of matching
+" parenthesis.
+"
+" It automatically skips matches found inside certain syntax regions like:
+" - escape (i.e. lispEscapeSpecial)
+" - symbol (i.e. lispBarSymbol)
+"
+" See `:help search" for the use of [flags].
+function! vlime#ui#SearchParenPos(flags)
+    let skipped_regions_fn = '!empty(filter(map(synstack(line("."), col(".")), ''synIDattr(v:val, "name")''), ' .
+        \ '''v:val =~? "string\\|character\\|singlequote\\|escape\\|symbol\\|comment"''))'
+
+    return searchpairpos('(', '', ')', a:flags, skipped_regions_fn)
 endfunction
 
 ""

--- a/vim/autoload/vlime/ui.vim
+++ b/vim/autoload/vlime/ui.vim
@@ -559,21 +559,14 @@ endfunction
 " Return the operator symbol name of the parentheses-enclosed expression under
 " the cursor. If no expression is found, return an empty string.
 function! vlime#ui#CurOperator()
-    let expr = vlime#ui#CurExpr()
-    if len(expr) > 0
-        let matches = matchlist(expr, '^(\_s*\(\k\+\)\_s*\_.*)$')
+    " There may be an incomplete expression, so instead of
+    " @function(vlime#ui#CurExpr) we use searchpairpos() instead
+    let [s_line, s_col] = vlime#ui#SearchParenPos('cbnW')
+    if s_line > 0 && s_col > 0
+        let op_line = getline(s_line)[(s_col-1):]
+        let matches = matchlist(op_line, '^(\s*\(\k\+\)\s*')
         if len(matches) > 0
             return matches[1]
-        endif
-    else
-        " There may be an incomplete expression
-        let [s_line, s_col] = searchpairpos('(', '', ')', 'cbnW')
-        if s_line > 0 && s_col > 0
-            let op_line = getline(s_line)[(s_col-1):]
-            let matches = matchlist(op_line, '^(\s*\(\k\+\)\s*')
-            if len(matches) > 0
-                return matches[1]
-            endif
         endif
     endif
     return ''

--- a/vim/autoload/vlime/ui.vim
+++ b/vim/autoload/vlime/ui.vim
@@ -465,7 +465,7 @@ function! vlime#ui#CurTopExprPos(...)
     let cur_level = 1
     try
         while type(max_level) == type(v:null) || cur_level <= max_level
-            let cur_pos = searchpairpos('(', '', ')', search_flags)
+            let cur_pos = vlime#ui#SearchParenPos(search_flags)
             if cur_pos[0] <= 0 || cur_pos[1] <= 0 ||
                         \ (type(max_lines) != type(v:null) && abs(old_cur_pos[1] - cur_pos[0]) > max_lines)
                 break
@@ -480,7 +480,7 @@ function! vlime#ui#CurTopExprPos(...)
         else
             let cur_char = vlime#ui#CurChar()
             if cur_char == '(' || cur_char == ')'
-                return searchpairpos('(', '', ')', search_flags . 'c')
+                return vlime#ui#SearchParenPos(search_flags . 'c')
             else
                 return [0, 0]
             endif

--- a/vim/autoload/vlime/ui.vim
+++ b/vim/autoload/vlime/ui.vim
@@ -345,6 +345,11 @@ let s:cur_expr_pos_search_flags = {
             \ 'end':   ['nW', 'cnW', 'nW'],
             \ }
 
+" List syntax types to skip when using searchpairpos():
+" - "escape" for special items, such as lispEscapeSpecial.
+" - "symbol" for odd symbols like `|nice-(|`
+let s:skipped_regions = 'string\|character\|singlequote\|comment\|escape\|symbol'
+
 ""
 " @usage {cur_char} [side]
 " @public
@@ -367,9 +372,8 @@ function! vlime#ui#CurExprPos(cur_char, ...)
       " Build an expression that detects whether the current cursor position is
       " in certain syntax types (string, comment, etc.), for use as
       " searchpairpos()'s skip argument.
-      " We match "escape" for special items, such as lispEscapeSpecial.
       let s_skip = '!empty(filter(map(synstack(line("."), col(".")), ''synIDattr(v:val, "name")''), ' .
-      \ '''v:val =~? "string\\|character\\|singlequote\\|escape\\|comment"''))'
+      \ '''v:val =~? s:skipped_regions''))'
       " If executing the expression determines that the cursor is currently in
       " one of the syntax types, then we want searchpairpos() to find the pair
       " within those syntax types (i.e., not skip).  Otherwise, the cursor is
@@ -583,7 +587,7 @@ function! vlime#ui#ParseOuterOperators(max_count)
     let old_cur_pos = getcurpos()
     try
         while len(stack) < a:max_count
-            let [p_line, p_col] = searchpairpos('(', '', ')', 'bnW')
+            let [p_line, p_col] = searchpairpos('(', '', ')', 'bnW', s:skipped_regions)
             if p_line <= 0 || p_col <= 0
                 break
             endif

--- a/vim/autoload/vlime/ui.vim
+++ b/vim/autoload/vlime/ui.vim
@@ -1112,7 +1112,7 @@ function! vlime#ui#CurArgPos(...)
     let arg_pos = -1
 
     if type(s_pos) == type(v:null)
-        let [s_line, s_col] = searchpairpos('(', '', ')', 'bnW')
+        let [s_line, s_col] = vlime#ui#SearchParenPos('bnW')
     else
         let [s_line, s_col] = s_pos
     endif
@@ -1153,6 +1153,10 @@ function! vlime#ui#CurArgPos(...)
 
             if index(syntax, 'lispComment') >= 0
                 " do nothing
+            elseif last_type == '\'
+                let last_type = 'i'
+            elseif ch == '\'
+                let last_type = '\'
             elseif ch == ' ' || ch == "\<tab>" || ch == "\n"
                 if last_type != 's' && last_type != ')' && paren_count == 1
                     let arg_pos += 1


### PR DESCRIPTION
Currently vlime's automatic indentation would break if a `#\(` is found
anywhere on a buffer.

Expected behavior:

    (defun open-parenthesis-p (ch)
      (char= ch #\())
    _ ; <-- cursor position

Actual behavior:

    (defun open-parenthesis-p (ch)
      (char= ch #\())
      _ ; <-- cursor position

The fix is to change the call to `searchpairpos()` inside
`vlime#ui#ParseOuterOperators()` to skip over specific syntax types
(e.g. special, and symbol)