### PR TITLE
Properly signal conditions on :SWANK-DATA-ERROR and :CLIENT-DATA-ERROR

### DIFF
--- a/lisp/src/vlime-usocket.lisp
+++ b/lisp/src/vlime-usocket.lisp
@@ -105,7 +105,8 @@
                                     swank-stream)
                     (finish-output swank-stream))
                   (t (c)
-                     (swank/backend:send control-thread `(:client-data-error ,c)))))
+                     (let ((msg (format nil "~A" c)))
+                       (swank/backend:send control-thread `(:client-data-error ,msg))))))
 
               (:swank-data
                 (vom:debug "swank-data msg")
@@ -116,7 +117,8 @@
                                     client-stream)
                     (finish-output client-stream))
                   (t (c)
-                     (swank/backend:send control-thread `(:swank-data-error ,c)))))
+                     (let ((msg (format nil "~A" c)))
+                       (swank/backend:send control-thread `(:swank-data-error ,msg))))))
 
               ((:exit :client-eof :swank-eof :client-data-error :swank-data-error)
                 (vom:info "Control thread stopping: ~s" msg)


### PR DESCRIPTION
As of today, if something goes wrong while connecting to the Swank
server (say because of a missing Swank contrib for example) users are be
presented with an error similar to the following:

      <INFO> [22:16:18] vlime-usocket - New client: #<USOCKET:STREAM-USOCKET {10046B29A3}>
      <INFO> [22:16:18] vlime-usocket - Control thread stopping: (:SWANK-DATA-ERROR
                                                                  #<SB-INT:SIMPLE-READER-PACKAGE-ERROR "Package ~A does not exist." {10049D57C3}>)

The signal'd condition is serialized into a string using the `~s` FORMAT
directive, and because of that, the actual information message which is
attached to it is kept hidden from the user, making it really difficult
to understand what went wrong.

With these changes, the above error message now becomes:

      <INFO> [21:56:44] vlime-usocket - Control thread stopping: (:SWANK-DATA-ERROR
                                                                  "Package CFFI-FEATURES does not exist.

Linked issue: https://github.com/vlime/vlime/issues/65#issuecomment-863542161