### PR TITLE
Hopefully the final bugfix for the :WRITE-DONE issue.

### DIFF
--- a/vim/autoload/vlime.vim
+++ b/vim/autoload/vlime.vim
@@ -45,7 +45,6 @@ function! vlime#New(...)
                 \ 'IsConnected': function('vlime#IsConnected'),
                 \ 'Close': function('vlime#Close'),
                 \ 'Call': function('vlime#Call'),
-                \ 'SendRaw': function('vlime#SendRaw'),
                 \ 'Send': function('vlime#Send'),
                 \ 'FixRemotePath': function('vlime#FixRemotePath'),
                 \ 'FixLocalPath': function('vlime#FixLocalPath'),
@@ -198,22 +197,12 @@ function! vlime#Call(msg) dict
     return vlime#compat#ch_evalexpr(self.channel, a:msg)
 endfunction
 
-" @dict VlimeConnection.Send
-" @usage {msg} [callback]
-" @private
-"
-" Send a raw message {msg} to the server.
-function! vlime#SendRaw(msg) dict
-    " TODO: remove that indirection?
-    return call('vlime#compat#ch_sendraw', [self.channel, a:msg])
-endfunction
-
 ""
 " @dict VlimeConnection.Send
 " @usage {msg} [callback]
 " @public
 "
-" Send a message {msg} to the server, and optionally register an async
+" Send a raw message {msg} to the server, and optionally register an async
 " [callback] function to handle the reply.
 function! vlime#Send(msg, ...) dict
     let Callback = get(a:000, 0, v:null)

--- a/vim/autoload/vlime/compat.vim
+++ b/vim/autoload/vlime/compat.vim
@@ -16,7 +16,6 @@ if !exists('s:ch_impl')
                     \ 'ch_close',
                     \ 'ch_evalexpr',
                     \ 'ch_sendexpr',
-                    \ 'ch_sendraw',
                 \ ])
 endif
 
@@ -65,9 +64,6 @@ function! vlime#compat#ch_sendexpr(chan, expr, ...)
     return s:ch_impl.ch_sendexpr(a:chan, a:expr, Callback)
 endfunction
 
-function! vlime#compat#ch_sendraw(chan, msg)
-    return s:ch_impl.ch_sendraw(a:chan, a:msg)
-endfunction
 
 function! vlime#compat#job_start(cmd, opts)
     return s:job_impl.job_start(a:cmd, a:opts)

--- a/vim/autoload/vlime/compat/neovim.vim
+++ b/vim/autoload/vlime/compat/neovim.vim
@@ -69,10 +69,6 @@ function! vlime#compat#neovim#ch_sendexpr(chan, expr, callback)
     endif
 endfunction
 
-function! vlime#compat#neovim#ch_sendraw(chan, msg)
-    return chansend(a:chan.ch_id, a:msg)
-endfunction
-
 
 function! vlime#compat#neovim#job_start(cmd, opts)
     let buf_name = a:opts['buf_name']

--- a/vim/autoload/vlime/compat/vim.vim
+++ b/vim/autoload/vlime/compat/vim.vim
@@ -44,10 +44,6 @@ function! vlime#compat#vim#ch_sendexpr(chan, expr, callback)
     endif
 endfunction
 
-function! vlime#compat#vim#ch_sendraw(chan, msg)
-    return ch_sendraw(a:chan, a:msg)
-endfunction
-
 
 function! vlime#compat#vim#job_start(cmd, opts)
     let buf_name = a:opts['buf_name']

--- a/vim/autoload/vlime/ui.vim
+++ b/vim/autoload/vlime/ui.vim
@@ -183,9 +183,9 @@ function! vlime#ui#OnWriteString(conn, str, str_type, ...) dict
                         \ [repl_buf, v:false, 'repl']))
     endif
     call vlime#ui#repl#AppendOutput(repl_buf, a:str)
-    if a:0 >= 1
+    if (a:0 >= 1) && (a:1 != v:null)
         " new as per slime 78ad57b7455be3f34a38da456183ddf8d604bdf8
-        call a:conn.SendRaw("(:write-done " .. a:1 .. ")")
+        call a:conn.Send([vlime#KW('VLIME-RAW-MSG'), "(:write-done " .. a:1 .. ")"])
     endif
 endfunction
 


### PR DESCRIPTION
Since I was not very familiar with the vlime internals, I tried to implement the SendRaw facilities in the last commit, but vlime was still bug ridden on my machine, so I dug deeper. The problem with commit cfaac6ccb379f9f85bfb2ef17ca6369dfadf2be6 is, that using ch_sendraw is the wrong approach, since it is just sending the raw expression string to the layer (implemented in vlime-protocol.lisp) which is responsible for converting vim's json-output to the swank-protocol format, so it could not be parsed by this layer.

The right way is to send a properly encoded message to this layer telling it to pass it as raw message to swank. It can be implemented via the Send() function, so the SendRaw()-Facilities are no longer needed and the previous commit is reverted.

The if-condition is further expanded, since the function vlime#onWriteString() may call onWriteString() with v:null as argument. 

I tested it with OpenBSD 7.3, SWANK 2.28 and it's running smoothely now. So i think this fixes ths Issues  #72 and #75. 